### PR TITLE
(GH-515) Integrate PDK Ruby API

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,11 +70,11 @@
     "onCommand:extension.puppetParserValidate",
     "onCommand:extension.puppetShowNodeGraphToSide",
     "onCommand:extension.puppetResource",
-    "onCommand:extension.pdkNewModule",
-    "onCommand:extension.pdkNewClass",
-    "onCommand:extension.pdkNewTask",
-    "onCommand:extension.pdkTestUnit",
-    "onCommand:extension.pdkValidate",
+    "onCommand:puppet.pdkNewModule",
+    "onCommand:puppet.pdkNewClass",
+    "onCommand:puppet.pdkNewTask",
+    "onCommand:puppet.pdkTestUnit",
+    "onCommand:puppet.pdkValidate",
     "onCommand:puppet-bolt.OpenUserConfigFile",
     "onCommand:puppet-bolt.OpenUserInventoryFile"
   ],
@@ -152,7 +152,7 @@
         "title": "Show Connection Logs"
       },
       {
-        "command": "extension.pdkNewModule",
+        "command": "puppet.pdkNewModule",
         "category": "Puppet",
         "title": "PDK New Module",
         "icon": {
@@ -161,22 +161,27 @@
         }
       },
       {
-        "command": "extension.pdkTestUnit",
+        "command": "puppet.pdkTestUnit",
         "category": "Puppet",
         "title": "PDK Test Unit"
       },
       {
-        "command": "extension.pdkValidate",
+        "command": "puppet.pdkValidate",
         "category": "Puppet",
         "title": "PDK Validate"
       },
       {
-        "command": "extension.pdkNewClass",
+        "command": "puppet.pdkNewClass",
         "category": "Puppet",
         "title": "PDK New Class"
       },
       {
-        "command": "extension.pdkNewTask",
+        "command": "puppet.pdkNewDefinedType",
+        "category": "Puppet",
+        "title": "PDK New Defined Type"
+      },
+      {
+        "command": "puppet.pdkNewTask",
         "category": "Puppet",
         "title": "PDK New Task"
       },
@@ -211,19 +216,22 @@
           "command": "extension.puppetShowConnectionLogs"
         },
         {
-          "command": "extension.pdkNewModule"
+          "command": "puppet.pdkNewModule"
         },
         {
-          "command": "extension.pdkTestUnit"
+          "command": "puppet.pdkTestUnit"
         },
         {
-          "command": "extension.pdkValidate"
+          "command": "puppet.pdkValidate"
         },
         {
-          "command": "extension.pdkNewClass"
+          "command": "puppet.pdkNewDefinedType",
         },
         {
-          "command": "extension.pdkNewTask"
+          "command": "puppet.pdkNewClass"
+        },
+        {
+          "command": "puppet.pdkNewTask"
         },
         {
           "command": "extension.puppetResource",
@@ -236,29 +244,34 @@
       ],
       "editor/title": [
         {
-          "command": "extension.pdkNewModule",
+          "command": "puppet.pdkNewModule",
           "when": "config.puppet.titleBar.pdkNewModule.enable",
           "group": "navigation@100"
         },
         {
           "when": "editorLangId == 'puppet'",
-          "command": "extension.pdkNewClass",
+          "command": "puppet.pdkNewClass",
           "group": "pdk@2"
         },
         {
           "when": "editorLangId == 'puppet'",
-          "command": "extension.pdkNewTask",
+          "command": "puppet.pdkNewDefinedType",
           "group": "pdk@3"
         },
         {
-          "when": "editorLangId == 'puppet' ",
-          "command": "extension.pdkValidate",
+          "when": "editorLangId == 'puppet'",
+          "command": "puppet.pdkNewTask",
           "group": "pdk@4"
         },
         {
           "when": "editorLangId == 'puppet'",
-          "command": "extension.pdkTestUnit",
+          "command": "puppet.pdkValidate",
           "group": "pdk@5"
+        },
+        {
+          "when": "editorLangId == 'puppet'",
+          "command": "puppet.pdkTestUnit",
+          "group": "pdk@6"
         },
         {
           "when": "editorLangId == 'puppet'",
@@ -274,23 +287,28 @@
       "editor/context": [
         {
           "when": "editorLangId == 'puppet'",
-          "command": "extension.pdkNewClass",
+          "command": "puppet.pdkNewClass",
           "group": "pdk@1"
         },
         {
           "when": "editorLangId == 'puppet'",
-          "command": "extension.pdkNewClass",
+          "command": "puppet.pdkNewDefinedType",
           "group": "pdk@2"
         },
         {
           "when": "editorLangId == 'puppet'",
-          "command": "extension.pdkValidate",
+          "command": "puppet.pdkNewTask",
           "group": "pdk@3"
         },
         {
           "when": "editorLangId == 'puppet'",
-          "command": "extension.pdkTestUnit",
+          "command": "puppet.pdkValidate",
           "group": "pdk@4"
+        },
+        {
+          "when": "editorLangId == 'puppet'",
+          "command": "puppet.pdkTestUnit",
+          "group": "pdk@5"
         },
         {
           "when": "editorLangId == 'puppet'",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,7 @@ import { OutputChannelLogger } from './logging/outputchannel';
 import { legacySettings, SettingsFromWorkspace } from './settings';
 import { Reporter, reporter } from './telemetry/telemetry';
 import { PuppetModuleHoverFeature } from './feature/PuppetModuleHoverFeature';
+import { PdkLanguageServerFeature } from './feature/PdkLangaugeServerFeature';
 
 const axios = require('axios');
 
@@ -53,13 +54,14 @@ export function activate(context: vscode.ExtensionContext) {
 
   reporter.sendTelemetryEvent('config', {
     'installType'   : configSettings.workspace.installType,
-    'protocol'      : configSettings.workspace.editorService.protocol
+    'protocol'      : configSettings.workspace.editorService.protocol,
+    'pdkVersion'    : configSettings.ruby.pdkVersion
   });
 
   const statusBar = new PuppetStatusBarFeature([puppetLangID, puppetFileLangID], configSettings, logger, context);
 
   extensionFeatures = [
-    new PDKFeature(extContext, logger),
+    new PDKFeature(extContext, logger, configSettings),
     new BoltFeature(extContext),
     new UpdateConfigurationFeature(logger, extContext),
     statusBar
@@ -94,6 +96,7 @@ export function activate(context: vscode.ExtensionContext) {
       break;
   }
 
+  extensionFeatures.push(new PdkLanguageServerFeature(connectionHandler, logger, extContext, settings));
   extensionFeatures.push(new FormatDocumentFeature(puppetLangID, connectionHandler, configSettings, logger, extContext));
   extensionFeatures.push(new NodeGraphFeature(puppetLangID, connectionHandler, logger, extContext));
   extensionFeatures.push(new PuppetResourceFeature(extContext, connectionHandler, logger));

--- a/src/feature/PdkLangaugeServerFeature.ts
+++ b/src/feature/PdkLangaugeServerFeature.ts
@@ -1,0 +1,117 @@
+import * as vscode from 'vscode';
+import { IFeature } from '../feature';
+import { ILogger } from '../logging';
+import { reporter } from '../telemetry/telemetry';
+import { ConnectionHandler } from '../handler';
+import { ConnectionStatus } from '../interfaces';
+import { RequestType } from 'vscode-languageclient';
+import { IAggregateConfiguration } from '../configuration';
+
+export class PdkLanguageServerFeature implements IFeature {
+  private terminal: vscode.Terminal;
+
+  constructor(
+    public handler: ConnectionHandler,
+    public logger: ILogger,
+    public ctx: vscode.ExtensionContext,
+    public settings: IAggregateConfiguration
+  ) {
+    [
+      { id: 'puppet.pdkNewClass', request: 'pdk/newClass', type: 'class' },
+      { id: 'puppet.pdkNewDefinedType', request: 'pdk/newDefinedType', type: 'type' },
+      { id: 'puppet.pdkNewTask', request: 'pdk/newTask', type: 'task' }
+    ].forEach(command => {
+      logger.debug(`Registered ${command.id} command`);
+      ctx.subscriptions.push(
+        vscode.commands.registerCommand(command.id, () => {
+          if (this.handler.status !== ConnectionStatus.RunningLoaded) {
+            vscode.window.showInformationMessage('PDK Commands are not available as the Language Server is not ready');
+            return Promise.resolve();
+          }
+
+          let nameOpts: vscode.QuickPickOptions = {
+            placeHolder: `Enter a name for the new Puppet ${command.type}`,
+            matchOnDescription: true,
+            matchOnDetail: true
+          };
+
+          vscode.window.showInputBox(nameOpts).then(async name => {
+            if (name === undefined) {
+              vscode.window.showWarningMessage(`No ${command.type} value specifed. Exiting.`);
+              return;
+            }
+
+            vscode.window.withProgress(
+              {
+                location: vscode.ProgressLocation.Notification,
+                title: `Creating Puppet ${command.type} - ${name}`,
+                cancellable: false
+              },
+              async progress => {
+                let targetFolder = vscode.workspace.workspaceFolders[0].uri.fsPath;
+                let requestParams = new PdkRequest(name, targetFolder);
+
+                await this.executeCommand(command, requestParams, progress);
+              }
+            );
+          });
+        })
+      );
+    });
+  }
+
+  private async executeCommand(
+    command: { id: string; request: string; type: string },
+    requestParams: PdkRequestParams,
+    progress: vscode.Progress<{ message?: string; increment?: number }>
+  ) {
+    await this.handler.languageClient
+      .sendRequest(new RequestType<PdkRequest, PdkResponse, void, void>(command.request), requestParams)
+      .then(async result => {
+        progress.report({ increment: 50 });
+        if (result.error) {
+          this.logger.error(result.error);
+          vscode.window.showErrorMessage(result.error);
+          return Promise.resolve();
+        } else {
+          if (reporter) {
+            reporter.sendTelemetryEvent(command.id, { pdkVersion: this.settings.ruby.pdkVersion });
+          }
+        }
+        let fileOne = result.files[0];
+        await this.openFile(fileOne, false);
+        if (result.files.length > 1) {
+          for (let index = 1; index < result.files.length; index++) {
+            let file = result.files[index];
+            this.openFile(file, true);
+          }
+        }
+        progress.report({ increment: 100 });
+      });
+  }
+
+  private async openFile(file: string, preserveFocus: boolean) {
+    await vscode.workspace.openTextDocument(vscode.Uri.file(file)).then(async doc => {
+      await vscode.window.showTextDocument(doc, vscode.ViewColumn.One, preserveFocus);
+    });
+  }
+
+  public dispose(): any {
+    this.terminal.dispose();
+  }
+}
+
+export interface PdkRequestParams {
+  name: string;
+  targetdir: string;
+}
+
+export class PdkRequest implements PdkRequestParams {
+  constructor(public name: string, public targetdir: string) {}
+}
+
+export interface PdkResponse {
+  files: string[];
+  data: string;
+  error: string;
+}

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -63,11 +63,3 @@ export class PuppetCommandStrings {
   static PuppetShowConnectionLogsCommandId = 'extension.puppetShowConnectionLogs';
   static PuppetUpdateConfigurationCommandId = 'extension.puppetUpdateConfiguration';
 }
-
-export class PDKCommandStrings {
-  static PdkNewModuleCommandId: string = 'extension.pdkNewModule';
-  static PdkNewClassCommandId: string = 'extension.pdkNewClass';
-  static PdkNewTaskCommandId: string = 'extension.pdkNewTask';
-  static PdkValidateCommandId: string = 'extension.pdkValidate';
-  static PdkTestUnitCommandId: string = 'extension.pdkTestUnit';
-}


### PR DESCRIPTION
This commit uses the PDK Ruby API instead of the pdk shell commands to
invoke PDK commands.

- [x] PDK New Class
- [x] PDK New Defined Type
- [ ] PDK New Module
- [x] PDK New Task

Part of https://github.com/lingua-pupuli/puppet-vscode/issues/515 implementation