### PR TITLE
(maint) Alert if jpogran.puppet-vscode installed

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,6 +35,15 @@ let configSettings: IAggregateConfiguration;
 let extensionFeatures: IFeature[] = [];
 
 export function activate(context: vscode.ExtensionContext) {
+  let pkg = vscode.extensions.getExtension('jpogran.puppet-vscode');
+  if (pkg){
+    let message = 'The "jpogran.puppet-vscode" extension has been detected, which will conflict with the "puppet.puppet-vscode" extension. This will cause problems activating when each extension tries to load at the same time and may cause errors. Please uninstall it by executing the following from the commandline: "code --uninstall-extension jpogran.puppet-vscode"';
+    vscode.window.showWarningMessage(
+      message,
+      { modal: false },
+    );
+  }
+
   extContext = context;
 
   setLanguageConfiguration();


### PR DESCRIPTION
This commit adds a warning if the `jpogran.puppet-vscode` extension is
installed while the `puppet.puppet-vscode` extension is. This can cause
a race condition where each extension tries to register at the same
time, which will produce error message popups.