### PR TITLE
(GH-647) Puppet Facts Welcome View

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Changed
 
 - (maint) Update facts view telemetry
+- ([GH-647](https://github.com/puppetlabs/puppet-vscode/issues/647)) Add Puppet Facts Welcome View
 
 ## [0.26.0] - 2020-05-01
 

--- a/package.json
+++ b/package.json
@@ -216,6 +216,12 @@
         }
       ]
     },
+    "viewsWelcome": [
+      {
+        "view": "puppetFacts",
+        "contents": "No facts foundn\n [Refresh](command:puppet.refreshFacts)"
+      }
+    ],
     "views": {
       "puppet-toolbar": [
         {


### PR DESCRIPTION
This commit adds a default welcome view to the Puppet Facts view if
there are no facts found.
