### PR TITLE
(maint) Fix Facts View typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -219,7 +219,7 @@
     "viewsWelcome": [
       {
         "view": "puppetFacts",
-        "contents": "No facts foundn\n [Refresh](command:puppet.refreshFacts)"
+        "contents": "No facts found\n[Refresh](command:puppet.refreshFacts)"
       }
     ],
     "views": {


### PR DESCRIPTION
This commit fixes the typo in declaring the welcome view for the facts
view.
