### PR TITLE
(GH-639) Deprecate Bolt commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Changed
 
 - ([GH-649](https://github.com/puppetlabs/puppet-vscode/issues/649)) Reduce activation events for extension
+- ([GH-639](https://github.com/puppetlabs/puppet-vscode/issues/639))  Deprecate Bolt Commands
 
 ## [0.26.1] - 2020-05-12
 

--- a/src/feature/BoltFeature.ts
+++ b/src/feature/BoltFeature.ts
@@ -6,9 +6,31 @@ import { reporter } from '../telemetry';
 
 export class BoltFeature implements IFeature {
   dispose() { }
+
+  showDeprecation(){
+    let message = 'The "Open Bolt User Configuration File" and "Open Bolt User Inventory File" commands will be removed in a future release. Do you think they should be kept? Think there are other ways for this extension to help using Puppet Bolt? Let us know by clicking "Feedback" to add a comment to Github Issue #639';
+    window.showWarningMessage(message,
+      { modal: false },
+      { title: 'Feedback' }
+    ).then(result => {
+      if (result === undefined) {
+        return;
+      }
+
+      if (result.title === 'Feedback') {
+        commands.executeCommand(
+          'vscode.open',
+          Uri.parse('https://github.com/puppetlabs/puppet-vscode/issues/639')
+        );
+      }
+    });
+  }
   constructor(context: ExtensionContext) {
+
     context.subscriptions.push(
       commands.registerCommand('puppet-bolt.OpenUserConfigFile', () => {
+        this.showDeprecation();
+
         let userInventoryFile = path.join(process.env['USERPROFILE'] || '~', '.puppetlabs', 'bolt', 'bolt.yaml');
 
         this.openOrCreateFile(
@@ -25,6 +47,8 @@ export class BoltFeature implements IFeature {
 
     context.subscriptions.push(
       commands.registerCommand('puppet-bolt.OpenUserInventoryFile', () => {
+        this.showDeprecation();
+
         let userInventoryFile = path.join(process.env['USERPROFILE'] || '~', '.puppetlabs', 'bolt', 'inventory.yaml');
 
         this.openOrCreateFile(


### PR DESCRIPTION
This commit removes the Bolt commands from the activation list and adds
a warning message notifying the user when they run the commands. It asks
the user for feedback by providing the github issue link for this
commit.
