### PR TITLE
(GH-649) Reduce Activation Events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Changed
+
+- ([GH-649](https://github.com/puppetlabs/puppet-vscode/issues/649)) Reduce activation events for extension
+
 ## [0.26.1] - 2020-05-12
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -59,18 +59,7 @@
     "workspaceContains:**/*.pp",
     "workspaceContains:**/*.epp",
     "workspaceContains:**/Puppetfile",
-    "onCommand:extension.puppetShowConnectionLogs",
-    "onCommand:extension.puppetShowConnectionMenu",
-    "onCommand:extension.puppetLint",
-    "onCommand:extension.puppetParserValidate",
-    "onCommand:extension.puppetResource",
-    "onCommand:extension.pdkNewModule",
-    "onCommand:extension.pdkNewClass",
-    "onCommand:extension.pdkNewTask",
-    "onCommand:extension.pdkTestUnit",
-    "onCommand:extension.pdkValidate",
-    "onCommand:puppet-bolt.OpenUserConfigFile",
-    "onCommand:puppet-bolt.OpenUserInventoryFile"
+    "onCommand:extension.pdkNewModule"
   ],
   "main": "./out/extension",
   "contributes": {


### PR DESCRIPTION
This PR removes unneeded activation points from the activationEvents field in the package.json. It was reported that the extension is activating at times when the user does not want it to, removing uncessary ones is the solution.

The Bolt commands would trigger activation of the extension when the command palate is used, even when there isn't any content in the workspace to warrant it.

The PDK Commands are only able to be used if inside a puppet module. The core activation events will cover making these commands available, so they can be removed.