### PR TITLE
(GH-663) Quote Workspace path

### DIFF
--- a/src/helpers/commandHelper.ts
+++ b/src/helpers/commandHelper.ts
@@ -143,7 +143,8 @@ export class CommandEnvironmentHelper {
 
     args.push('--timeout=' + settings.workspace.editorService.timeout);
     if (vscode.workspace.workspaceFolders !== undefined) {
-      args.push('--local-workspace=' + vscode.workspace.workspaceFolders[0].uri.fsPath);
+      const path = `--local-workspace='${vscode.workspace.workspaceFolders[0].uri.fsPath}'`;
+      args.push(path);
     }
 
     // Convert the individual puppet settings into the --puppet-settings


### PR DESCRIPTION
This PR fixes a bug that occurs if the workspace path has a space or other non-standard character. This would cause a command line parsing error when trying to execute the language server.
