### PR TITLE
(GH-670) Guard installType and installDirectory

### DIFF
--- a/package.json
+++ b/package.json
@@ -472,17 +472,21 @@
         },
         "puppet.installDirectory": {
           "type": "string",
-          "default": null,
-          "description": "The fully qualified path to the Puppet install directory. This can be a PDK or Puppet Agent installation. For example: 'C:\\Program Files\\Puppet Labs\\Puppet' or '/opt/puppetlabs/puppet'. If this is not set the extension will attempt to detect the installation directory"
+          "markdownDescription": "The fully qualified path to the Puppet install directory. This can be a PDK or Puppet Agent installation. For example: 'C:\\Program Files\\Puppet Labs\\Puppet' or '/opt/puppetlabs/puppet'. If this is not set the extension will attempt to detect the installation directory. Do **not** use when `#puppet.installType#` is set to `auto`"
         },
         "puppet.installType": {
           "type": "string",
           "default": "auto",
-          "description": "The type of Puppet installation. Either the Puppet Development Kit (pdk) or the Puppet Agent (agent). Choose 'auto' to have the extension detect which to use automatically based on default install locations",
+          "markdownDescription": "The type of Puppet installation. Either the Puppet Development Kit (pdk) or the Puppet Agent (agent). Choose `auto` to have the extension detect which to use automatically based on default install locations",
           "enum": [
             "auto",
             "pdk",
             "agent"
+          ],
+          "enumDescriptions": [
+            "The exention will use the PDK or the Puppet Agent based on default install locations. When both are present, it will use the PDK",
+            "Use the PDK as an installation source",
+            "Use the Puppet Agent as an installation source"
           ]
         },
         "puppet.notification.nodeGraph": {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -170,6 +170,22 @@ export function SettingsFromWorkspace(): ISettings {
     pdk: workspaceConfig.get<IPDKSettings>('pdk', defaults.pdk),
   };
 
+  if (settings.installDirectory && settings.installType === PuppetInstallType.AUTO) {
+    const message =
+      "Do not use 'installDirectory' and set 'installType' to auto. The 'installDirectory' setting" +
+      ' is meant for custom installation directories that will not be discovered by the extension';
+    const title = 'Configuration Information';
+    const helpLink = 'https://puppet-vscode.github.io/docs/extension-settings';
+    vscode.window.showErrorMessage(message, { modal: false }, { title: title }).then((item) => {
+      if (item === undefined) {
+        return;
+      }
+      if (item.title === title) {
+        vscode.commands.executeCommand('vscode.open', vscode.Uri.parse(helpLink));
+      }
+    });
+  }
+
   /**
    * Legacy Workspace Settings
    *


### PR DESCRIPTION
Add more explanation to the settings for installDirectory and installType using new VS Code Settings API that explains when to use each setting. Add a guard clause early on in the activation process that warns when settings are used that are incompatible.

The extension works when there is both pdk and agent present, and when only one is present. The problem here is that the settings for the extension are not helping the user choose successful configurations and allowing mixing of settings that then produce incorrect paths to the parts of puppet we need.

The intention for auto was to not use installDirectory or installType, so that the extension would choose whether to use pdk or agent and which paths to use itself. This was intended to make the default 'happy path' the situation where a user has pdk installed to the default path and not require the user to set any settings.
