### PR TITLE
(GH-678) Remove Invalid Configuration Defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+### Fixed
+
+- ([GH-678](https://github.com/puppetlabs/puppet-vscode/issues/678)) Remove invalid Configuration Defaults
+
 ## [0.27.0] - 2020-06-08
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -360,11 +360,6 @@
       ]
     },
     "configurationDefaults": {
-      "files.encoding": "utf8",
-      "files.associations": [
-        ".pp",
-        ".epp"
-      ],
       "[puppet]": {
         "editor.tabSize": 2,
         "editor.insertSpaces": true,


### PR DESCRIPTION
Removes the encoding and file associations from the configurationDefaults section because as of vscode 1.24, you are no longer allowed to set settings for anything outside the language the extension is providing.
