### PR TITLE
(GH-684) Fix pdk new module activation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,10 +69,14 @@ export function activate(context: vscode.ExtensionContext) {
     pdkVersion: configSettings.ruby.pdkVersion,
   });
 
-  const puppetfile = path.join(vscode.workspace.workspaceFolders[0].uri.fsPath, 'Puppetfile');
-  const exists = fs.existsSync(puppetfile);
-  if (exists && configSettings.workspace.editorService.enable) {
-    vscode.commands.executeCommand('setContext', 'puppet:puppetfileEnabled', true);
+  const workspaceFolders = vscode.workspace.workspaceFolders;
+  if (workspaceFolders) {
+    const currentWorkspaceFolder = workspaceFolders[0];
+    const puppetfile = path.join(currentWorkspaceFolder.uri.fsPath, 'Puppetfile');
+    const exists = fs.existsSync(puppetfile);
+    if (exists && configSettings.workspace.editorService.enable) {
+      vscode.commands.executeCommand('setContext', 'puppet:puppetfileEnabled', true);
+    }
   }
 
   const statusBar = new PuppetStatusBarFeature([puppetLangID, puppetFileLangID], configSettings, logger, context);


### PR DESCRIPTION
This fixes a bug when a user tries to use the 'PDK new Module' button in a VS Code window that is empty or has no workspace open. This bug was introduced when the Puppetfile view was added and did not properly catch this error case.
