### PR TITLE
(GH-681) Activate extension when puppet module

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "workspaceContains:**/*.pp",
     "workspaceContains:**/*.epp",
     "workspaceContains:**/Puppetfile",
+    "workspaceContains:**/lib/puppet",
     "onCommand:extension.pdkNewModule"
   ],
   "main": "./out/extension",


### PR DESCRIPTION
Add an activation event for `lib/puppet` to activate when puppet modules with no puppet manifests or Puppetfiles are present. These kinds of modules have traditional type and providers that are ruby files and not puppet files.
