### PR TITLE
(GH-703) Prepare for 1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+Major release 🎉🎉 which drops support for Puppet 4
+
+- ([GH-272](https://github.com/puppetlabs/puppet-editor-services/issues/272)) [puppet-editor-services-1.0.0](https://github.com/lingua-pupuli/puppet-editor-services/releases/tag/1.0.0) Fix Puppet Lint and document symbol sometimes not working
+- ([GH-269](https://github.com/puppetlabs/puppet-editor-services/issues/269)) [puppet-editor-services-1.0.0](https://github.com/lingua-pupuli/puppet-editor-services/releases/tag/1.0.0) Fix Workspace Symbol Provider
+- ([Commit](https://github.com/puppetlabs/puppet-editor-services/commit/7c4a9c4d2d868bdbea1ef590300d5a37fce9b1e4)) [puppet-editor-services-1.0.0](https://github.com/lingua-pupuli/puppet-editor-services/releases/tag/1.0.0) Update Puppetfile Resolver to 0.3.0
+- ([Commit](https://github.com/puppetlabs/puppet-editor-services/commit/450b9acaabe58eeee52da4000910673647d25d13)) [puppet-editor-services-1.0.0](https://github.com/lingua-pupuli/puppet-editor-services/releases/tag/1.0.0) Document removal of Puppet 4
+- ([GH-209](https://github.com/puppetlabs/puppet-editor-services/issues/209)) [puppet-editor-services-1.0.0](https://github.com/lingua-pupuli/puppet-editor-services/releases/tag/1.0.0) Refactor the session state to be a class and pass that instead of global modules
+- ([Commit](https://github.com/puppetlabs/puppet-editor-services/commit/f7caae3f7b0db4e1debecafe8bd4c3485a334732)) [puppet-editor-services-1.0.0](https://github.com/lingua-pupuli/puppet-editor-services/releases/tag/1.0.0) Removed vendored gems and update development and building workflows
+- ([Commit](https://github.com/puppetlabs/puppet-editor-services/commit/2f6e0fc143ddd50be5256bf9abb62d91d2e49466)) [puppet-editor-services-1.0.0](https://github.com/lingua-pupuli/puppet-editor-services/releases/tag/1.0.0) Fix Facter Helper for 1.0
+- ([GH-252](https://github.com/puppetlabs/puppet-editor-services/issues/252)) [puppet-editor-services-1.0.0](https://github.com/lingua-pupuli/puppet-editor-services/releases/tag/1.0.0) Use puppet-strings by default and remove feature flag
+- ([Commit](https://github.com/puppetlabs/puppet-editor-services/commit/bc3db27182ad47253e29a86a6cace73292b86d30)) [puppet-editor-services-1.0.0](https://github.com/lingua-pupuli/puppet-editor-services/releases/tag/1.0.0) Vendor puppet-strings and Yard
+- ([Commit](https://github.com/puppetlabs/puppet-editor-services/commit/5a4800434dbed1756148905464011f882b7e2191)) [puppet-editor-services-1.0.0](https://github.com/lingua-pupuli/puppet-editor-services/releases/tag/1.0.0) Remove support for Puppet 4
+
 ## [0.28.0] - 2020-07-20
 
 ### Added
@@ -100,7 +113,6 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 ### Fixed
 
 - ([GH-207](https://github.com/lingua-pupuli/puppet-editor-services/issues/207)) [puppet-editor-services-0.25.0](https://github.com/lingua-pupuli/puppet-editor-services/releases/tag/0.25.0) Allow Qualified Resource Names in hover provider
-
 
 ## [0.24.2] - 2020-03-30
 
@@ -568,7 +580,7 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 - Initial release of the puppet extension.
 
-[Unreleased]: https://github.com/lingua-pupuli/puppet-vscode/compare/0.28.0...master
+[unreleased]: https://github.com/lingua-pupuli/puppet-vscode/compare/0.28.0...master
 [0.28.0]: https://github.com/lingua-pupuli/puppet-vscode/compare/0.27.3...0.28.0
 [0.27.3]: https://github.com/lingua-pupuli/puppet-vscode/compare/0.27.2...0.27.3
 [0.27.2]: https://github.com/lingua-pupuli/puppet-vscode/compare/0.27.1...0.27.2

--- a/README.md
+++ b/README.md
@@ -74,17 +74,17 @@ This extension provides full Puppet Language support for [Visual Studio Code](ht
 - (Experimental) Local debugging of Puppet manifests
 - **DEPRECATED** Docker Language Server support
 
-**It is currently in technical preview, so that we can gather bug reports and find out what new features to add.**
-
 ## Supported Puppet Versions
 
-The Puppet Extension for VSCode works with Puppet 4 or higher. Some features will be slower or not work on Puppet 4, and are noted in the section for that feature. See [open source Puppet](https://puppet.com/docs/puppet/5.5/about_agent.html) and [Puppet Enterprise](https://puppet.com/docs/pe/2017.3/getting_support_for_pe.html#supported-puppet-enterprise-versions) lifecycle pages for version support details.
+The Puppet Extension for VSCode works with Puppet 5 or higher. See [open source Puppet](https://puppet.com/docs/puppet/5.5/about_agent.html) and [Puppet Enterprise](https://puppet.com/docs/pe/2017.3/getting_support_for_pe.html#supported-puppet-enterprise-versions) lifecycle pages for version support details.
 
 ## Requirements
 
 You will need to have the [Puppet Development Kit (PDK)](https://puppet.com/docs/pdk/1.x/pdk.html) or [Puppet Agent](https://puppet.com/docs/puppet/latest/about_agent.html) installed in order to fully use this extension.
 
 > Note: When using PDK, version 1.5.0 or higher is required.
+
+> Note: When using Puppet Agent, version 5.0 or higher is required.
 
 You can find instructions and installation links here:
 

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "puppet-vscode",
   "displayName": "Puppet",
   "description": "Official Puppet VSCode extension. Provides full Puppet DSL intellisense, syntax highlighting, Puppet command support, Puppet node graphs, and much more",
-  "version": "0.28.0",
+  "version": "1.0.0",
   "editorComponents": {
     "editorServices": {
-      "release": "0.26.1"
+      "release": "1.0.0"
     },
     "editorSyntax": {
       "release": "1.3.7"


### PR DESCRIPTION
This commit prepares the VSCode extension for a 1.0.0 release, with that actual
date yet to be determined.
