### PR TITLE
(GH-709) Puppetfile autocomplete

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "puppet-vscode",
-  "version": "0.28.0",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,7 @@ import { BoltFeature } from './feature/BoltFeature';
 import { DebuggingFeature } from './feature/DebuggingFeature';
 import { FormatDocumentFeature } from './feature/FormatDocumentFeature';
 import { PDKFeature } from './feature/PDKFeature';
+import { PuppetfileCompletionFeature } from './feature/PuppetfileCompletionFeature';
 import { PuppetfileHoverFeature } from './feature/PuppetfileHoverFeature';
 import { PuppetModuleHoverFeature } from './feature/PuppetModuleHoverFeature';
 import { PuppetNodeGraphFeature } from './feature/PuppetNodeGraphFeature';
@@ -87,6 +88,7 @@ export function activate(context: vscode.ExtensionContext) {
     new UpdateConfigurationFeature(logger, extContext),
     statusBar,
     new PuppetfileHoverFeature(extContext, logger),
+    new PuppetfileCompletionFeature(extContext, logger),
   ];
 
   if (configSettings.workspace.editorService.enable === false) {

--- a/src/feature/PuppetfileCompletionFeature.ts
+++ b/src/feature/PuppetfileCompletionFeature.ts
@@ -1,0 +1,50 @@
+import * as vscode from 'vscode';
+import { IFeature } from '../feature';
+import { getPuppetModuleCompletion } from '../forge';
+import { ILogger } from '../logging';
+
+export class PuppetfileCompletionProvider implements vscode.CompletionItemProvider {
+  constructor(public logger: ILogger) {}
+  async provideCompletionItems(
+    document: vscode.TextDocument,
+    position: vscode.Position,
+    token: vscode.CancellationToken,
+    context: vscode.CompletionContext,
+  ): Promise<vscode.CompletionItem[] | vscode.CompletionList> {
+    // get all text until the `position` and check if it reads `mod.`
+    const linePrefix = document.lineAt(position).text.substr(0, position.character);
+    if (!linePrefix.startsWith('mod')) {
+      return undefined;
+    }
+
+    const completionText = document.getText(document.getWordRangeAtPosition(position));
+
+    const data = await getPuppetModuleCompletion(completionText, this.logger);
+
+    const l: vscode.CompletionList = new vscode.CompletionList();
+    data.modules.forEach((element) => {
+      l.items.push(new vscode.CompletionItem(element, vscode.CompletionItemKind.Module));
+    });
+
+    return l;
+  }
+
+  resolveCompletionItem?(
+    item: vscode.CompletionItem,
+    token: vscode.CancellationToken,
+  ): vscode.ProviderResult<vscode.CompletionItem> {
+    throw new Error('Method not implemented.');
+  }
+}
+
+export class PuppetfileCompletionFeature implements IFeature {
+  constructor(public context: vscode.ExtensionContext, public logger: ILogger) {
+    const selector = [{ scheme: 'file', language: 'puppetfile' }];
+    context.subscriptions.push(
+      vscode.languages.registerCompletionItemProvider(selector, new PuppetfileCompletionProvider(logger)),
+    );
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  dispose() {}
+}


### PR DESCRIPTION
This PR adds a Puppetfile CompletionItemProvider that queries the Puppet Forge for a list of matching Puppet modules, then provides a list menu to select an item.