### PR TITLE
(GH-724) PDK New Module with Native window

### DIFF
--- a/src/feature/PDKFeature.ts
+++ b/src/feature/PDKFeature.ts
@@ -1,3 +1,5 @@
+'use strict';
+
 import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
@@ -47,25 +49,21 @@ export class PDKFeature implements IFeature {
       { id: 'extension.pdkNewDefinedType', request: 'pdk new defined_type', type: 'Puppet defined_type' },
     ].forEach((command) => {
       context.subscriptions.push(
-        vscode.commands.registerCommand(command.id, () => {
-          const nameOpts: vscode.QuickPickOptions = {
-            placeHolder: `Enter a name for the new ${command.type}`,
-            matchOnDescription: true,
-            matchOnDetail: true,
-          };
-
-          vscode.window.showInputBox(nameOpts).then((name) => {
-            if (name === undefined) {
-              vscode.window.showWarningMessage(`No ${command.type} value specifed. Exiting.`);
-              return;
-            }
-            const request = `${command.request} ${name}`;
-            this.terminal.sendText(request);
-            this.terminal.show();
-            if (reporter) {
-              reporter.sendTelemetryEvent(command.id);
-            }
+        vscode.commands.registerCommand(command.id, async () => {
+          const name = await vscode.window.showInputBox({
+            prompt: `Enter a name for the new ${command.type}`,
           });
+          if (name === undefined) {
+            vscode.window.showWarningMessage('No module name specifed. Exiting.');
+            return;
+          }
+
+          const request = `${command.request} ${name}`;
+          this.terminal.sendText(request);
+          this.terminal.show();
+          if (reporter) {
+            reporter.sendTelemetryEvent(command.id);
+          }
         }),
       );
       logger.debug(`Registered ${command.id} command`);


### PR DESCRIPTION
This PR updates the `PDK New Module` command to use the native window picker instead of asking the user to enter in the fully qualified path. It also opens the newly created module inside the window the command was issued in, instead of opening a new VS Code window.

By using the native window picker, we get the correct experience on WIndows, Mac and Linxu. Even inside WSL or Remote Containers:

![image](https://user-images.githubusercontent.com/272569/106325581-07ec6680-6249-11eb-81e3-405493f1f97f.png)

