### PR TITLE
(GH-730) Fix ffi 1.14 libssp-0.dll missing with PDK 2.0

### DIFF
--- a/src/helpers/commandHelper.ts
+++ b/src/helpers/commandHelper.ts
@@ -219,6 +219,11 @@ export class CommandEnvironmentHelper {
     exe.options.env.PATH = this.buildPathArray([
       config.ruby.pdkBinDir,
       config.ruby.pdkRubyBinDir,
+      // temporary fix for ffi 1.14.2
+      // remove when pdk 2.X comes out https://github.com/puppetlabs/puppet-vscode/issues/730
+      path.join(config.ruby.puppetBaseDir, 'private', 'git', 'mingw64', 'bin'),
+      path.join(config.ruby.puppetBaseDir, 'private', 'git', 'mingw64', 'libexec', 'git-core'),
+      path.join(config.ruby.puppetBaseDir, 'private', 'git', 'usr', 'bin'),
       exe.options.env.PATH,
     ]);
   }


### PR DESCRIPTION
This commit adds the git binary paths to the PATH environment variable to address the missing libssp-0.dll in ffi 1.14. This can be removed once ffi 1.15 is distributed with Puppet and the PDK.
