### PR TITLE
(GH-748) Update Editor Services to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "1.2.0",
   "editorComponents": {
     "editorServices": {
-      "release": "1.1.0"
+      "release": "1.2.0"
     },
     "editorSyntax": {
       "release": "1.3.7"

--- a/package.json
+++ b/package.json
@@ -426,6 +426,11 @@
           "default": [],
           "description": "An array of strings of experimental features to enable in the Puppet Editor Service"
         },
+        "puppet.editorService.foldingRange.enable": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable/disable syntax aware code folding provider."
+        },
         "puppet.editorService.formatOnType.enable": {
           "type": "boolean",
           "default": false,


### PR DESCRIPTION
Pending 1.2.0 release PR - https://github.com/puppetlabs/puppet-editor-services/pull/308

---

(GH-748) Update Puppet Editor Services to 1.2.0

This commit updates PES to 1.2.0.

---

(GH-748) Update settings for Editor Services 1.2.0

This commit adds the puppet.editorService.foldingRange.enable setting which was
introduced as part of Puppet Editor Services 1.2.0.