### PR TITLE
(GH-748) Update settings for Editor Services 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -429,7 +429,12 @@
         "puppet.editorService.foldingRange.enable": {
           "type": "boolean",
           "default": true,
-          "description": "Enable/disable syntax aware code folding provider."
+          "description": "Enable/disable syntax aware code folding provider"
+        },
+        "puppet.editorService.foldingRange.showLastLine": {
+          "type": "boolean",
+          "default": false,
+          "description": "Show or hide the last line in code folding regions"
         },
         "puppet.editorService.formatOnType.enable": {
           "type": "boolean",


### PR DESCRIPTION
Previously the puppet.editorService.foldingRange.enable setting was added
however the showLastLine setting was missed.  This commit adds the showLastLine
setting as per the Editor Service v1.2.0 changes.

<!--
BEFORE YOU CREATE A PULL REQUEST:

Ensure you have read over

CONTRIBUTING - https://github.com/puppetlabs/puppet-vscode/blob/master/CONTRIBUTING.md

and

CODE_OF_CONDUCT - https://github.com/puppetlabs/puppet-vscode/blob/master/CODE_OF_CONDUCT.md

We provide defined guidance (as such, we strongly adhere to it).

A summary of our expectations:
 - You are not submitting a pull request from your MASTER branch.
 - YOUR GIT COMMIT MESSAGE FORMAT IS EXTREMELY IMPORTANT. We have a very defined expectation for this format and are sticklers about it. Really, READ the entire Contributing document. It will save you and us pain.
 - Do not reformat code, it makes it hard to see what has changed. Leave the formatting to us.

THANKS! We appreciate you reading the entire Contributing document and not just scanning through it.

DELETE EVERYTHING IN THIS COMMENT BLOCK
-->
