### PR TITLE
(MAINT) Bump GHA node version to 14x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
     - '[0-9].[0-9]+.[0-9]+' # Push events matching all semantic versioning tags, i.e. 0.26.01, 1.0, v20.15.10
 
 env:
-  NODE_VERSION: '12.x'
+  NODE_VERSION: '14.x'
 
 jobs:
   release:

--- a/.github/workflows/vscode-ci.yml
+++ b/.github/workflows/vscode-ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [10]
+        node-version: [14]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:


### PR DESCRIPTION
Prior to this commit, GHA failed on an unexpected token reference.
For more info, see:

https://github.com/microsoft/vscode-vsce/issues/653

This commit updates the GHA workflows to use node 14x instead.
