### PR TITLE
Detect suspended terminal on start

### DIFF
--- a/src/feature/PDKFeature.ts
+++ b/src/feature/PDKFeature.ts
@@ -12,7 +12,9 @@ export class PDKFeature implements IFeature {
   private terminal: vscode.Terminal;
 
   constructor(context: vscode.ExtensionContext, logger: ILogger) {
-    this.terminal = vscode.window.createTerminal('Puppet PDK');
+    const suspendedTerm = vscode.window.terminals.find((tm) => tm.name === 'Puppet PDK');
+    this.terminal = suspendedTerm === undefined ? vscode.window.createTerminal('Puppet PDK') : suspendedTerm;
+
     this.terminal.processId.then((pid) => {
       logger.debug('pdk shell started, pid: ' + pid);
     });


### PR DESCRIPTION
This commit detects if there is an existing suspended terminal named 'Puppet PDK' and uses that instead of blindly creating a new one. If no terminal is found, it creates it's own.

Previously VS Code removed all disposed terminals created by extensions on close. VS Code has since enabled suspending terminals, which persist shutting off VS Code and are reanimated when started again.

The PDK command integration was built before the possibility of terminal suspension. When this extension starts, it creates a integrated terminal to use for PDK Commands, which is then suspended on VS Code close. When it's started again, this extension creates a new terminal, resulting in duplicate terminals. Adding logic to detect existing terminals removes this problem.
