### PR TITLE
(GH-825) fix duplicate PDK terminals

### DIFF
--- a/src/feature/PuppetStatusBarFeature.ts
+++ b/src/feature/PuppetStatusBarFeature.ts
@@ -31,7 +31,6 @@ class PuppetStatusBarProvider {
   }
 
   public setConnectionStatus(statusText: string, status: ConnectionStatus, toolTip: string): void {
-    this.logger.debug(`Setting status bar to ${statusText}`);
     // Icons are from https://octicons.github.com/
     let statusIconText: string;
     let statusColor: string;


### PR DESCRIPTION
This PR fixes the issue where a new VSCode terminal named "Puppet PDK" was created on every window reload.
This is done by moving terminal creation from the constructor of the PDK feature to the command functions themselves.
This has the consequence that the terminal is now not created when the user opens VSCode, but when a PDK command is issued from the command palette.