### PR TITLE
(CONT-987) Address deprecation warnings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Node ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/vscode-ci.yml
+++ b/.github/workflows/vscode-ci.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: 'setup node: ${{ matrix.node-version }} platform: ${{ matrix.os }}'
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           fetch-depth: 1
           node-version: ${{ matrix.node-version }}


### PR DESCRIPTION
Deprecation warnings in github workflows  "Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/setup-node@v1". This commit uses actions/setup-node@v3 instead of v1.

