### PR TITLE
(CAT-1422) - Add Language Server Input to release_prep

### DIFF
--- a/.github/workflows/release_prep.yml
+++ b/.github/workflows/release_prep.yml
@@ -7,6 +7,9 @@ on:
         description: 'Version to released.'
         required: true
         default: '0.0.0'
+      language-server-version:
+        description: 'Version of language server for release to consume. In the format v0.0.0'
+        required: false
 
 jobs:
   release_prep:
@@ -29,9 +32,12 @@ jobs:
 
       - name: "Update Version"
         run: |
-          current_version=$(jq --raw-output .version package.json)
-          # Update version in package.json, only matching first occurrence
-          sed -i "0,/$current_version/s//${{ github.event.inputs.version }}/" $(find . -name 'package.json')
+          cat <<< $(jq '.version="${{ github.event.inputs.version }}"' package.json) > package.json
+
+      - name: "Update Language Server Version"
+        if: "${{ github.event.inputs.language-server-version != '' }}"
+        run: |
+          cat <<< $(jq '.editorComponents.editorServices.release="${{ github.event.inputs.language-server-version}}"' package.json) > package.json
 
       - name: "Generate package-lock.json"
         run: |


### PR DESCRIPTION
## Summary
This PR will now allow maintainers to specify the version of the language server to be shipped with the new vscode extension release.


## Additional Context
Use of more concise syntax - opted for jq over sed.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified.

## Verification 
When a language server release is provided -> https://github.com/puppetlabs/puppet-vscode/pull/848
When a language server release is not provided -> https://github.com/puppetlabs/puppet-vscode/pull/849/ & https://github.com/puppetlabs/puppet-vscode/actions/runs/6421160889/job/17434877805 (step is skipped)
