### PR TITLE
(CAT-1491) - Fix broken forge urls in Puppetfile

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -40,7 +40,7 @@ Happy linting! 💖
     "no-template-curly-in-string": "error",
     "require-atomic-updates": "error",
     "no-useless-backreference": "error",
-    "@typescript-eslint/class-name-casing": "warn",
+    "@typescript-eslint/naming-convention": "warn",
     "@typescript-eslint/member-delimiter-style": [
       "warn",
       {

--- a/src/forge.ts
+++ b/src/forge.ts
@@ -57,7 +57,7 @@ export function getPDKVersion(logger: ILogger): Promise<string> {
       .then((response) => {
         if (response.status !== 200) {
           logger.error(`Error getting Puppet forge data. Status: ${response.status}:${response.statusText}`);
-          resolve();
+          resolve(void 0);
         }
         return response.data;
       });
@@ -80,7 +80,7 @@ export function getModuleInfo(title: string, logger: ILogger): Promise<PuppetFor
       .then((response) => {
         if (response.status !== 200) {
           logger.error(`Error getting Puppet forge data. Status: ${response.status}:${response.statusText}`);
-          resolve();
+          resolve(void 0);
         }
 
         const info = response.data;
@@ -93,7 +93,7 @@ export function getModuleInfo(title: string, logger: ILogger): Promise<PuppetFor
           created: new Date(info.created_at),
           updated: new Date(info.updated_at),
           endorsement: info.endorsement ?? '',
-          forgeUrl: `https://forge.puppet.com/${info.owner.username}/${info.name}`,
+          forgeUrl: `https://forge.puppet.com/modules/${info.owner.username}/${info.name}`,
           homepageUrl: info.homepage_url ?? '',
           version: info.current_release.version,
           owner: {
@@ -109,7 +109,7 @@ export function getModuleInfo(title: string, logger: ILogger): Promise<PuppetFor
       })
       .catch((error) => {
         logger.error(`Error getting Puppet forge data: ${error}`);
-        resolve();
+        resolve(void 0);
       });
   });
 }
@@ -130,7 +130,7 @@ export function getPuppetModuleCompletion(text: string, logger: ILogger): Promis
       .then((response) => {
         if (response.status !== 200) {
           logger.error(`Error getting Puppet forge data. Status: ${response.status}:${response.statusText}`);
-          resolve();
+          resolve(void 0);
         }
 
         const info = response.data;
@@ -144,7 +144,7 @@ export function getPuppetModuleCompletion(text: string, logger: ILogger): Promis
       })
       .catch((error) => {
         logger.error(`Error getting Puppet forge data: ${error}`);
-        resolve();
+        resolve(void 0);
       });
   });
 }

--- a/src/forge.ts
+++ b/src/forge.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention */
 import axios from 'axios';
 import { extensions, MarkdownString } from 'vscode';
 import { ILogger } from './logging';
@@ -46,7 +47,6 @@ export function getPDKVersion(logger: ILogger): Promise<string> {
     return axios
       .get('https://s3.amazonaws.com/puppet-pdk/pdk/LATEST', {
         params: {
-          // eslint-disable-next-line @typescript-eslint/camelcase
           exclude_fields: 'readme changelog license reference',
         },
         headers: {
@@ -57,7 +57,7 @@ export function getPDKVersion(logger: ILogger): Promise<string> {
       .then((response) => {
         if (response.status !== 200) {
           logger.error(`Error getting Puppet forge data. Status: ${response.status}:${response.statusText}`);
-          resolve(void 0);
+          resolve(undefined);
         }
         return response.data;
       });
@@ -69,7 +69,6 @@ export function getModuleInfo(title: string, logger: ILogger): Promise<PuppetFor
     return axios
       .get(`https://forgeapi.puppet.com/v3/modules/${title}`, {
         params: {
-          // eslint-disable-next-line @typescript-eslint/camelcase
           exclude_fields: 'readme changelog license reference',
         },
         headers: {
@@ -80,7 +79,7 @@ export function getModuleInfo(title: string, logger: ILogger): Promise<PuppetFor
       .then((response) => {
         if (response.status !== 200) {
           logger.error(`Error getting Puppet forge data. Status: ${response.status}:${response.statusText}`);
-          resolve(void 0);
+          resolve(undefined);
         }
 
         const info = response.data;
@@ -109,7 +108,7 @@ export function getModuleInfo(title: string, logger: ILogger): Promise<PuppetFor
       })
       .catch((error) => {
         logger.error(`Error getting Puppet forge data: ${error}`);
-        resolve(void 0);
+        resolve(undefined);
       });
   });
 }
@@ -119,7 +118,6 @@ export function getPuppetModuleCompletion(text: string, logger: ILogger): Promis
     return axios
       .get(`https://forgeapi.puppet.com/private/modules?starts_with=${text}`, {
         params: {
-          // eslint-disable-next-line @typescript-eslint/camelcase
           exclude_fields: 'readme changelog license reference',
         },
         headers: {
@@ -130,7 +128,7 @@ export function getPuppetModuleCompletion(text: string, logger: ILogger): Promis
       .then((response) => {
         if (response.status !== 200) {
           logger.error(`Error getting Puppet forge data. Status: ${response.status}:${response.statusText}`);
-          resolve(void 0);
+          resolve(undefined);
         }
 
         const info = response.data;
@@ -144,7 +142,7 @@ export function getPuppetModuleCompletion(text: string, logger: ILogger): Promis
       })
       .catch((error) => {
         logger.error(`Error getting Puppet forge data: ${error}`);
-        resolve(void 0);
+        resolve(undefined);
       });
   });
 }


### PR DESCRIPTION
## Summary
This PR fixes an issue where when hovering over a module in a Puppetfile, the forge url shown would be invalid.

This PR aims to fix this by fixing the url, in the format now used in forge urls.

## Additional Context
**Before:**
<img width="422" alt="image" src="https://github.com/puppetlabs/puppet-vscode/assets/112936862/29a1206a-db94-45a5-8a97-345d52646e5f">
**After:**
![image](https://github.com/puppetlabs/puppet-vscode/assets/112936862/c7c1cace-2c5b-4a21-9fb7-5779174a183e)

## Related Issues (if any)
Fixes https://github.com/puppetlabs/puppet-vscode/issues/824

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
