### PR TITLE
(maint) - Update requirements for vscode

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The Puppet Extension for VSCode works with Puppet 5 or higher. See [open source 
 
 You will need to have the [Puppet Development Kit (PDK)](https://puppet.com/docs/pdk/1.x/pdk.html) or [Puppet Agent](https://puppet.com/docs/puppet/latest/about_agent.html) installed in order to fully use this extension.
 
-> Note: When using PDK, version 2.7.0 or higher is required.
+> Note: When using PDK, version 3.0.0 or higher is required.
 
 > Note: When using Puppet Agent, version 7.0 or higher is required.
 


### PR DESCRIPTION
## Summary
Bump required PDK version.
A bug appeared in the puppet versions bundled with pdk v2.7.x , which was rectified in pdk v3.x, and since only the most recent major release of PDK is supported we will bump the minimum required version for PDK puppet installation type in puppet-vscode.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
