### PR TITLE
(maint) - run ci with puppet 8 on linux

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,8 +24,8 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 & echo ">>> Started xvfb";
-          wget https://apt.puppetlabs.com/puppet6-release-trusty.deb;
-          sudo dpkg -i puppet6-release-trusty.deb;
+          wget https://apt.puppetlabs.com/puppet8-release-jammy.deb;
+          sudo dpkg -i puppet8-release-jammy.deb;
           sudo apt-get update -y;
           sudo apt-get install pdk -y;
           pdk --version;

--- a/.github/workflows/vscode-ci.yml
+++ b/.github/workflows/vscode-ci.yml
@@ -25,8 +25,8 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 & echo ">>> Started xvfb";
-          wget https://apt.puppetlabs.com/puppet6-release-trusty.deb;
-          sudo dpkg -i puppet6-release-trusty.deb;
+          wget https://apt.puppetlabs.com/puppet8-release-jammy.deb;
+          sudo dpkg -i puppet8-release-jammy.deb;
           sudo apt-get update -y;
           sudo apt-get install pdk -y;
           pdk --version;


### PR DESCRIPTION
## Summary
run the ci on puppet 8 as oppose to the now unsupported puppet 6

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
