### PR TITLE
(bug) - Render task schema directly from GitHub

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # Setting ownership to the tooling team
-* @puppetlabs/tooling
+* @puppetlabs/devx

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
       },
       {
         "fileMatch": "tasks/*.json",
-        "url": "https://forgeapi.puppet.com/schemas/task.json"
+        "url": "https://raw.githubusercontent.com/puppetlabs/puppet-specifications/master/tasks/task.json"
       }
     ],
     "grammars": [


### PR DESCRIPTION
## Summary
Prior to this PR, we relied on the forge api to return the bolt task schema json.
However, the endpoint in the forge has been broken for sometime, so it brought the necessity for the call to the forge api to our attention.

We have decided now to opt to retrieve it directly from GitHub ourselves, removing the need for the forge api in this case.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
