### PR TITLE
(bug) - Fix module hover in metadata.json

### DIFF
--- a/src/feature/PuppetModuleHoverFeature.ts
+++ b/src/feature/PuppetModuleHoverFeature.ts
@@ -42,8 +42,19 @@ export class PuppetModuleHoverProvider implements vscode.HoverProvider {
     if (reporter) {
       reporter.sendTelemetryEvent('metadataJSON/Hover');
     }
+    const wordPattern = new RegExp(/[\w/-]+/);
+    let range = document.getWordRangeAtPosition(position, wordPattern);
 
-    const range = document.getWordRangeAtPosition(position);
+    // If the range does not include the full module name, adjust the range
+    if (!range.contains(position)) {
+      const lineText = document.lineAt(position.line).text;
+      const quoteIndex = lineText.indexOf('"', position.character);
+      if (quoteIndex !== -1) {
+        const start = lineText.lastIndexOf('"', position.character) + 1;
+        const end = quoteIndex;
+        range = new vscode.Range(position.line, start, position.line, end);
+      }
+    }
     const word = document.getText(range);
 
     this.logger.debug('Metadata hover info found ' + word + ' module');


### PR DESCRIPTION
## Summary
This PR fixes the module hover in metadata.json. Before it was returning just `puppetlabs` i.e. the module namespace, as oppose to the entire module name for example `puppetlabs/stdlib`.

Now, this calculates the position and returns the entire string, which can they be used to query the forge api for module data.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified.
