### PR TITLE
(GH-878) - Fix Puppetfile Hover for format owner/module

### DIFF
--- a/src/feature/PuppetfileHoverFeature.ts
+++ b/src/feature/PuppetfileHoverFeature.ts
@@ -31,6 +31,7 @@ class PuppetfileHoverProvider implements vscode.HoverProvider {
       .replace(new RegExp('mod\\s+'), '')
       .replace(new RegExp(",\\s+'\\d.\\d.\\d\\'"), '')
       .replace(new RegExp(',\\s+:latest'), '')
+      .replace("/", '-')
       .replace("'", '')
       .replace("'", '');
 


### PR DESCRIPTION
## Summary
Fixes an issue where a valid Puppetfile which declares a module like below
```
forge 'https://forge.puppet.com'

mod 'puppetlabs/stdlib', '9.4.0'
```
would not supply hover information.

This was due to a missing replace statement in ./src/feature/PuppetfileHoverFeature.ts, which neglected to replace the `/` with a `-` to form a valid forge slug for API querying.

## Additional Context
see https://github.com/puppetlabs/puppet-vscode/issues/878

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified.
