### PR TITLE
(CAT-1669) - Fix hashrocket allignment on completion item select

### DIFF
--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,0 +1,66 @@
+import * as assert from 'assert';
+import { after, before, beforeEach, describe, it } from 'mocha';
+import * as sinon from 'sinon';
+import * as vscode from 'vscode';
+import { provideCompletionItemMiddleware } from '../../extension';
+import { PuppetStatusBarFeature } from '../../feature/PuppetStatusBarFeature';
+import { ISettings, settingsFromWorkspace } from '../../settings';
+
+describe('Extension Tests', () => {
+  let vscodeCommandsRegisterCommandStub: sinon.SinonStub;
+  let puppetStatusBarFeatureStub: sinon.SinonStub;
+  let settings: ISettings;
+  let context: vscode.ExtensionContext;
+  let registerDebugAdapterDescriptorFactoryStub: sinon.SinonStub;
+  let document: vscode.TextDocument;
+  let position: vscode.Position;
+  let completionContext: vscode.CompletionContext;
+  let token: vscode.CancellationToken;
+  let next: sinon.SinonStub
+  const sandbox = sinon.createSandbox();
+
+  before(() => {
+    vscodeCommandsRegisterCommandStub = sandbox.stub(vscode.commands, 'registerCommand');
+    settings = settingsFromWorkspace();
+    context = {
+      subscriptions: [],
+      asAbsolutePath: (relativePath: string) => {
+        return `/absolute/path/to/${relativePath}`;
+      },
+      globalState: {
+        get: sandbox.stub(),
+      }
+    } as vscode.ExtensionContext;
+    puppetStatusBarFeatureStub = sandbox.createStubInstance(PuppetStatusBarFeature);
+    registerDebugAdapterDescriptorFactoryStub = sandbox.stub(vscode.debug, 'registerDebugAdapterDescriptorFactory');
+  });
+
+  beforeEach(() => {
+    document = {} as vscode.TextDocument;
+    position = new vscode.Position(0, 0);
+    completionContext = {} as vscode.CompletionContext;
+    token = new vscode.CancellationTokenSource().token;
+    next = sandbox.stub();
+  });
+
+  after(() => {
+    sandbox.restore();
+  });
+
+  it('should add command to completion items', async () => {
+    const completionItems = [
+      new vscode.CompletionItem('item1', vscode.CompletionItemKind.Property),
+      new vscode.CompletionItem('item2', vscode.CompletionItemKind.Text),
+    ];
+    completionItems[0].detail = 'Property';
+    completionItems[1].detail = 'Text';
+    next.returns(completionItems);
+
+    const result = await provideCompletionItemMiddleware.provideCompletionItem(document, position, context, token, next);
+
+    assert.ok(Array.isArray(result));
+    assert.strictEqual(result.length, 2);
+    assert.strictEqual(result[0].command?.command, 'editor.action.formatDocumentAndMoveCursor');
+    assert.strictEqual(result[1].command?.command, 'editor.action.formatDocument');
+  });
+});


### PR DESCRIPTION
## Summary
Prior to this PR, when selecting a param/prop from the dropdown completion list in puppet-vscode, the hash rocket would not be formatted inline with the rest of the document.

This PR implements a middleware to the language client, and adds a vscode API item command which allows us to execute a vscode command after the selection of the param/prop from the dropdown list. So when an param/prop is selected, we send a callback event to the language server to format the document.

This is only possible on the vscode side thanks to the vscode API, unfortunately there is no suitable events to implement this into the langauge server.
Also not possible as:
1. The LSP does not provide adamant data to the language-server to retrieve the file content and then format on the language server side
2. Even still, there is no way to guarantee correct formatting when we can only return the completion item, as if we returned the entire formatted document that would be inserted where the cursor is, leading to duplicate and inconsistent formatting with props/params.

## Related Issues (if any)
Fixes https://github.com/puppetlabs/puppet-vscode/issues/884

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified.
